### PR TITLE
Skip assemblies missing Machine.Specifications.dll

### DIFF
--- a/Source/Machine.VSTestAdapter/MspecTestAdapterExecutor.cs
+++ b/Source/Machine.VSTestAdapter/MspecTestAdapterExecutor.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
+using System.IO;
 using Machine.VSTestAdapter.Execution;
 using Machine.VSTestAdapter.Helpers;
 using Machine.VSTestAdapter.Configuration;
@@ -30,6 +31,12 @@ namespace Machine.VSTestAdapter
             {
                 try
                 {
+                    if (!File.Exists(Path.Combine(Path.GetDirectoryName(Path.GetFullPath(currentAsssembly)),"Machine.Specifications.dll")))
+                    {
+                        frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format("Machine.Specifications.dll not found for {0}", currentAsssembly));
+                        continue;
+                    }
+
                     frameworkHandle.SendMessage(TestMessageLevel.Informational, String.Format(Strings.EXECUTOR_EXECUTINGIN, currentAsssembly));
 
                     this.executor.RunAssembly(currentAsssembly, settings, uri, frameworkHandle);


### PR DESCRIPTION
Uses the same logic as in test discovery
Resolves bug where assemblies that weren't discovered were trying to be
tested but throwing errors due to missing dll