### PR TITLE
added traversing through declaring types to obtain full context display name

### DIFF
--- a/Source/Machine.VSTestAdapter.Specs/Discovery/BuiltIn/When_discovering_specs_in_nested_types.cs
+++ b/Source/Machine.VSTestAdapter.Specs/Discovery/BuiltIn/When_discovering_specs_in_nested_types.cs
@@ -14,6 +14,8 @@ namespace Machine.VSTestAdapter.Specs.Discovery.BuiltIn
                                                                           "NestedSpec".Equals(x.ClassName, StringComparison.Ordinal));
             discoveredSpec.ShouldNotBeNull();
 
+            discoveredSpec.ContextDisplayName.ShouldEqual("Parent NestedSpec");
+
             discoveredSpec.LineNumber.ShouldEqual(14);
             discoveredSpec.CodeFilePath.EndsWith("NestedSpecSample.cs", StringComparison.Ordinal);
         };

--- a/Source/Machine.VSTestAdapter.Specs/Discovery/Cecil/When_discovering_specs_in_nested_types.cs
+++ b/Source/Machine.VSTestAdapter.Specs/Discovery/Cecil/When_discovering_specs_in_nested_types.cs
@@ -14,6 +14,8 @@ namespace Machine.VSTestAdapter.Specs.Discovery.Cecil
                                                                           "NestedSpec".Equals(x.ClassName, StringComparison.Ordinal));
             discoveredSpec.ShouldNotBeNull();
 
+            discoveredSpec.ContextDisplayName.ShouldEqual("Parent NestedSpec");
+
             discoveredSpec.LineNumber.ShouldEqual(14);
             discoveredSpec.CodeFilePath.EndsWith("NestedSpecSample.cs", StringComparison.Ordinal);
         };

--- a/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
+++ b/Source/Machine.VSTestAdapter/Discovery/BuiltIn/TestDiscoverer.cs
@@ -33,7 +33,8 @@ namespace Machine.VSTestAdapter.Discovery.BuiltIn
 
                 testCase.ClassName = context.Type.Name;
                 testCase.ContextFullType = context.Type.FullName;
-                testCase.ContextDisplayName = context.Type.Name.Replace("_", " ");
+                testCase.ContextDisplayName = GetContextDisplayName(context.Type);
+
                 testCase.SpecificationName = spec.FieldInfo.Name;
                 testCase.SpecificationDisplayName = spec.Name;
 
@@ -59,6 +60,18 @@ namespace Machine.VSTestAdapter.Discovery.BuiltIn
 
                 yield return testCase;
             }
+        }
+
+        private string GetContextDisplayName(Type contextType)
+        {
+            var displayName = contextType.Name.Replace("_", " ");
+
+            if (contextType.IsNested)
+            {
+                return GetContextDisplayName(contextType.DeclaringType) + " " + displayName;
+            }
+
+            return displayName;
         }
 
         public override object InitializeLifetimeService()

--- a/Source/Machine.VSTestAdapter/Discovery/Cecil/CecilSpecificationDiscoverer.cs
+++ b/Source/Machine.VSTestAdapter/Discovery/Cecil/CecilSpecificationDiscoverer.cs
@@ -68,7 +68,7 @@ namespace Machine.VSTestAdapter.Discovery.Cecil
                                 ClassName = typeName,
                                 ContextFullType = typeFullName,
                                 SpecificationName = fieldDefinition.Name,
-                                ContextDisplayName = typeName.Replace("_", " "),
+                                ContextDisplayName = GetContextDisplayName(type),
                                 SpecificationDisplayName = fieldDefinition.Name.Replace("_", " "),
                             };
 
@@ -81,6 +81,18 @@ namespace Machine.VSTestAdapter.Discovery.Cecil
                 }
             }
             return list.Select(x => x);
+        }
+
+        private string GetContextDisplayName(TypeDefinition typeDefinition)
+        {
+            var displayName = NormalizeCecilTypeName(typeDefinition.Name).Replace("_", " ");
+
+            if (typeDefinition.IsNested)
+            {
+                return GetContextDisplayName(typeDefinition.DeclaringType) + " " + displayName;
+            }
+
+            return displayName;
         }
 
         private IEnumerable<TypeDefinition> GetNestedTypes(Collection<TypeDefinition> types)


### PR DESCRIPTION
![capture](https://cloud.githubusercontent.com/assets/2878612/18577095/5dfbc216-7be7-11e6-93aa-d00fdccca1c6.PNG)

see attached picture for example of nested test display name